### PR TITLE
Fix repository EF query methods

### DIFF
--- a/Common/Common.Infrastructure/Repositories/GenericRepository.cs
+++ b/Common/Common.Infrastructure/Repositories/GenericRepository.cs
@@ -10,7 +10,7 @@ public class GenericRepository<TEntity, TContext>(TContext context)
     private readonly DbSet<TEntity> _set = context.Set<TEntity>();
 
     public async Task<TEntity?> GetByIdAsync(Guid id, CancellationToken ct = default) =>
-        await _set.FindAsync([id], ct);
+        await _set.FindAsync(new object?[] { id }, ct);
 
     public async Task<IReadOnlyList<TEntity>> ListAsync(
         Expression<Func<TEntity, bool>>? predicate = null,

--- a/Modules/User/Infrastructure/Repositories/UserRepository.cs
+++ b/Modules/User/Infrastructure/Repositories/UserRepository.cs
@@ -10,7 +10,7 @@ public class UserRepository(UserDbContext dbContext) : GenericRepository<User,Us
 
     public async Task<User?> GetAsync(Guid id, CancellationToken cancellationToken = default)
     {
-        return await _dbContext.Users.FindAsync([id, cancellationToken], cancellationToken: cancellationToken);
+        return await _dbContext.Users.FindAsync(new object?[] { id }, cancellationToken: cancellationToken);
     }
 
     public async Task InsertAsync(User user, CancellationToken cancellationToken = default)

--- a/Modules/User/Infrastructure/UserDbContext.cs
+++ b/Modules/User/Infrastructure/UserDbContext.cs
@@ -12,7 +12,5 @@ public class UserDbContext(DbContextOptions<UserDbContext> options) : DbContext(
     {
         base.OnModelCreating(modelBuilder);
         modelBuilder.Entity<User>().ToCollection("users");
-
-        base.OnModelCreating(modelBuilder);
     }
 }


### PR DESCRIPTION
## Summary
- fix invalid `FindAsync` usages in GenericRepository and UserRepository
- remove duplicate base call in `UserDbContext.OnModelCreating`

## Testing
- `dotnet build --no-restore`
- `dotnet test` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_683f4c832cc483259c6899b45e01d8c3